### PR TITLE
Refactoring SCSS part

### DIFF
--- a/generators/app/templates/_gulpfile.js
+++ b/generators/app/templates/_gulpfile.js
@@ -78,28 +78,12 @@ gulp.task('clean', function() {
 // Precompile .scss and concat with ionic.css
 gulp.task('styles', function() {
 
-	var options = build ? { style: 'compressed' } : { style: 'expanded' };
+	var options = build ? { outputStyle: 'compressed' } : { outputStyle: 'expanded' };
 
-	var sassStream = gulp.src(config.path.src.asset.scss + '/main.scss')
+	return gulp.src(config.path.src.asset.scss + '/main.scss')
 		.pipe(plugins.sass(options))
-		.on('error', function(err) {
-			console.log('err: ', err);
-		});
-
-	// Build ionic css dynamically to support custom themes
-	var ionicStream = gulp.src(config.path.src.asset.scss + '/ionic-styles.scss')
-		.pipe(plugins.cached('ionic-styles'))
-		.pipe(plugins.sass(options))
-		// Cache and remember ionic .scss in order to cut down re-compile time
-		.pipe(plugins.remember('ionic-styles'))
-		.on('error', function(err) {
-			console.log('err: ', err);
-		});
-
-	return streamqueue({ objectMode: true }, ionicStream, sassStream)
 		.pipe(plugins.autoprefixer(config.autoprefix.support.split(', ')))
 		.pipe(plugins.concat('main.css'))
-		.pipe(plugins.if(build, plugins.stripCssComments()))
 		.pipe(plugins.if(build && !emulate, plugins.rev()))
 		.pipe(gulp.dest(path.join(targetDir, 'styles')))
 		.on('error', errorHandler);

--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -30,7 +30,6 @@
 		"gulp-rev": "^6.0.1",
 		"gulp-sass": "^2.0.4",
 		"gulp-shell": "^0.5.1",
-		"gulp-strip-css-comments": "^1.2.0",
 		"gulp-strip-debug": "^1.1.0",
 		"gulp-uglify": "^1.5.1",
 		"gulp-util": "^3.0.7",

--- a/generators/app/templates/src/styles/_variables.scss
+++ b/generators/app/templates/src/styles/_variables.scss
@@ -1,5 +1,15 @@
 /**
  * Define variables here
+ *
+ * e.g. $textColor: #ccc;
  */
 
-$textColor: #ccc;
+
+
+
+
+/**
+ * Override Ionic variables here
+ *
+ * e.g. $positive:  #387ef5 !default;
+ */

--- a/generators/app/templates/src/styles/ionic-styles.scss
+++ b/generators/app/templates/src/styles/ionic-styles.scss
@@ -1,8 +1,0 @@
-/**
- * Override Ionic variables here
- *
- * e.g. $positive:  #387ef5 !default;
- */
-
-// Include all of Ionic for compilation
-@import 'bower_components/ionic/scss/ionic';

--- a/generators/app/templates/src/styles/main.scss
+++ b/generators/app/templates/src/styles/main.scss
@@ -4,23 +4,33 @@
  *
  ************************************/
 
+/**
+ * Ionic & custor variables
+ */
 @import "_variables";
 
+
 /**
- * LAYOUT
+ * Vendor / Ionic styles
+ */
+@import 'bower_components/ionic/scss/ionic';
+
+
+/**
+ * Layout
  */
 
 @import "layout/layout";
 
 
 /**
- * MENU
+ * Menu
  */
 
 @import "menu/menu";
 
 /**
- * VIEWS
+ * Views
  */
 
 @import "views/home";

--- a/test/app.js
+++ b/test/app.js
@@ -69,7 +69,6 @@ describe('generator-ionic-incubator:app', function() {
 	it('copied scss files', function() {
 		assert.file([
 			'src/styles/_variables.scss',
-			'src/styles/ionic-styles.scss',
 			'src/styles/main.scss',
 			'src/styles/layout/layout.scss',
 			'src/styles/menu/menu.scss',


### PR DESCRIPTION
- Moved ionic-styles.scss to main.scss as an import
- Moved ionic variables to _variabled.scss
- Fixed bug: changed 'style' to 'outputStyle' in SCSS Gulp task
- Removed plugin 'gulp-strip-css-comments' anymore because outputStyle:compressed was never used
